### PR TITLE
Update helmDeploy to require chart version

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -562,6 +562,7 @@ function tail_job_logs {
 
 function helm_deploy() {
   local chart="${BUILDKITE_PLUGIN_K8S_DEPLOY_CHART}"
+  local chart_version="${BUILDKITE_PLUGIN_K8S_DEPLOY_CHART_VERSION}"
   local release="${BUILDKITE_PLUGIN_K8S_DEPLOY_RELEASE}"
   local tag="${BUILDKITE_PLUGIN_K8S_DEPLOY_TAG}"
   local namespace="${BUILDKITE_PLUGIN_K8S_DEPLOY_NAMESPACE:-default}"
@@ -570,7 +571,7 @@ function helm_deploy() {
 
   set -o pipefail
 
-  echo "--- :helm: Update ${release} of ${chart} to use the image tag ${tag}"
+  echo "--- :helm: Update release (${release}) with tag(${tag}) using chart (${chart}) at version (${chart_version})"
 
   # Update the repo index - all repos
   helm repo update
@@ -579,34 +580,27 @@ function helm_deploy() {
   echo "${BUILDKITE_PLUGIN_K8S_DEPLOY_VALUES}" > "${values_file}"
 
   exit_code=0
-  # Check that the requested release already present
-  status=$(helm status ${release} -n "${namespace}" | grep STATUS | cut -c 9-)
 
-  if [ "$?" -ne "0" ]; then
-    # Create a new release as requested
-    echo ":confused: Release ${release} not found, creating"
+  helm_status=$(helm status "${release}" -n "${namespace}")
+  deploy_status=$(echo "${helm_status}" | grep STATUS |cut -c 9-)
 
-    helm install --atomic -f "${values_file}" --set image.tag="${tag}" -n "${namespace}" --timeout "${timeout}" --debug "${release}" "${chart}"
-
-    if [ "$?" -ne "0" ]; then
-      echo "--- :bk-status-failed: Failed to install ${release} of ${chart}"
-      exit_code=1
-    fi
-
-  elif [ "${status}" != "deployed" ]; then
-      echo "--- :bk-status-failed: ${release} is in the wrong status '${status}' - expected 'deployed'"
-      exit_code=1
-  else
-    echo ":slightly_smiling_face: Found ${release}, updating"
-
-    # Upgrade the image tag for the selected release
-    helm upgrade --atomic -f "${values_file}" --set image.tag="${tag}" -n "${namespace}" --timeout "${timeout}" --debug "${release}" "${chart}"
-
-    if [ "$?" -ne "0" ]; then
-      echo "--- :bk-status-failed: Failed to update ${release} of ${chart}"
-      exit_code=1
-    fi
-  fi
+  case "$deploy_status" in
+      unknown|uninstalled|superseded|failed|uninstalling|pending-install|pending-upgrade|pending-rollback)
+          echo "--- :bk-status-failed: ${release} is in the wrong status '${deploy_status}' - expected 'deployed'"
+          exit_code=1
+          ;;
+      deployed|"")
+          if [ "$deploy_status" == "" ]; then
+              # Create a new release as requested
+              echo ":confused: Release ${release} not found, creating"
+          fi
+          if ! helm upgrade --install --atomic -f "${values_file}" --set image.tag="${tag}" -n "${namespace}" --timeout "${timeout}" --debug "${release}" --version "${chart_version}" "${chart}";
+          then
+              echo "--- :bk-status-failed: Failed to update ${release} of ${chart} with version ${chart_version}"
+              exit_code=1
+          fi
+          ;;
+  esac
 
   rm -f "${values_file}"
   exit $exit_code

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,9 @@
+## Testing this plugin
+
+Follow the guidelines in the [Buildkite plugins documentation](https://buildkite.com/docs/plugins/writing#step-5-add-a-test). The easist way to run these tests is with Docker using this command:
+
+```sh
+docker run -it --rm -v "$PWD:/plugin:ro" buildkite/plugin-tester
+```
+
+Take a look at the [plugin test documentation](https://github.com/buildkite-plugins/buildkite-plugin-tester) to find out how to use assertions, mocks etc.

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,20 +1,64 @@
 #!/usr/bin/env bats
 
-load '/usr/local/lib/bats/load.bash'
+load "$BATS_PLUGIN_PATH/load.bash"
 
 # Uncomment the following line to debug stub failures
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 
-@test "Creates an annotation with the file count" {
-  export BUILDKITE_PLUGIN_FILE_COUNTER_PATTERN="*.bats"
+setup() {
+    export BUILDKITE_PLUGIN_K8S_DEPLOY_CHART="test-chart"
+    export BUILDKITE_PLUGIN_K8S_DEPLOY_CHART_VERSION="0.1.14"
+    export BUILDKITE_PLUGIN_K8S_DEPLOY_RELEASE="test-release"
+    export BUILDKITE_PLUGIN_K8S_DEPLOY_TAG="a932ae5ee92598f76edae9a476cfc7f9e574a679"
+    export BUILDKITE_PLUGIN_K8S_DEPLOY_ACTION="helmDeploy"
+}
 
-  stub buildkite-agent 'annotate "Found 1 files matching *.bats" : echo Annotation created'
+teardown() {
+  unstub helm
+}
 
-  run "$PWD/hooks/post-command"
+@test "exits if release is in wrong status" {
+    stub helm \
+         "repo update : echo 'helm repo update called'" \
+         "status \* \* \* : echo 'STATUS: pending-upgrade'"
 
-  assert_success
-  assert_output --partial "Found 1 files matching *.bats"
-  assert_output --partial "Annotation created"
+    run "$PWD/hooks/command"
 
-  unstub buildkite-agent
+    assert_failure
+    assert_output --partial "is in the wrong status 'pending-upgrade'"
+}
+
+@test "exits if helm upgrade fails" {
+    stub helm \
+         "repo update : echo 'helm repo update called'" \
+         "status \* \* \* : echo 'STATUS: deployed'" \
+         "upgrade \*  \*  \*  \*  \*  \*  \*  \*  \*  \*  \*  \*  \*  \*  \*  \* : echo \${15}; exit 1"
+    run "$PWD/hooks/command"
+
+    assert_failure
+    assert_output --partial "Failed to update test-release of test-chart with version 0.1.14"
+}
+
+@test "outputs message if release is not found and will be created" {
+    stub helm \
+         "repo update : echo 'helm repo update called'" \
+         "status \* \* \* : echo 'Not found'" \
+         "upgrade \*  \*  \*  \*  \*  \*  \*  \*  \*  \*  \*  \*  \*  \*  \*  \* : echo \${15}; exit 0"
+
+    run "$PWD/hooks/command"
+
+    assert_success
+    assert_output --partial "Release test-release not found, creating"
+}
+
+@test "calls helm upgrade with chart version" {
+    stub helm \
+         "repo update : echo 'helm repo update called'" \
+         "status \* \* \* : echo 'STATUS: deployed'" \
+         "upgrade \*  \*  \*  \*  \*  \*  \*  \*  \*  \*  \*  \*  \*  \*  \*  \* : echo \${15}; exit 0"
+
+    run "$PWD/hooks/command"
+
+    assert_success
+    assert_output --partial "0.1.14"
 }


### PR DESCRIPTION
- plugin now uses chart version when installing or upgrading with helm.
- uses --install on the helm upgrade command to create release if necessary
- split helm_status and deploy_status to make testing easier
- added bats tests