### PR TITLE
Remove ecr login

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  tests:
+    image: buildkite/plugin-tester:v4.1.1
+    volumes:
+      - ".:/plugin"

--- a/hooks/command
+++ b/hooks/command
@@ -354,16 +354,7 @@ function updateDeployment () {
 }
 
 function promoteImage () {
-    # Login to source repository
-
-    aws ecr get-login-password --region $BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_REGION | docker login --username AWS --password-stdin $BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_REPOSITORYURL
-    if [ $? -ne 0 ]; then
-        echo "--- :bk-status-failed: Promotion failed. Authentication failed with source repository"
-        exit 1
-    fi
-
     # Test if the image already exists on the kubernetes host
-
     local should_cleanup_source_image=1
 
     if docker inspect --type=image $BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_REPOSITORYURL/$BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_IMAGE ; then
@@ -372,7 +363,6 @@ function promoteImage () {
     fi
 
     # Pull the source image
-
     docker pull $BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_REPOSITORYURL/$BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_IMAGE
     if [ $? -ne 0 ]; then
         echo "--- :bk-status-failed: Promotion failed. Failed to pull source image"
@@ -380,7 +370,6 @@ function promoteImage () {
     fi
 
     # Loop over destinations and push in parallel
-
     local i=0
     local destination_image_envvar="BUILDKITE_PLUGIN_K8S_DEPLOY_DESTINATIONIMAGES_${i}_IMAGE"
     local destination_repository_url_envvar="BUILDKITE_PLUGIN_K8S_DEPLOY_DESTINATIONIMAGES_${i}_REPOSITORYURL"
@@ -389,13 +378,6 @@ function promoteImage () {
     local push_pids=()
 
     while [[ -n "${!destination_image_envvar:-}" ]] ; do
-        # Authenticate with the destination region
-        aws ecr get-login-password --region ${!destination_region_envvar} | docker login --username AWS --password-stdin ${!destination_repository_url_envvar}
-        if [ $? -ne 0 ]; then
-            echo "--- :bk-status-failed: Promotion failed. Authentication failed with destination repository ${!destination_repository_url_envvar}"
-            exit 1
-        fi
-
         # Tag and push the image
         docker tag $BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_REPOSITORYURL/$BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_IMAGE ${!destination_repository_url_envvar}/${!destination_image_envvar}
 
@@ -410,7 +392,6 @@ function promoteImage () {
     done
 
     # Wait for each image push to complete
-
     local failure_count=0
 
     for i in ${!push_pids[@]}; do
@@ -419,7 +400,6 @@ function promoteImage () {
         local push_exit_code=$?
 
         # Cleanup the tag locally
-
         destination_image_envvar="BUILDKITE_PLUGIN_K8S_DEPLOY_DESTINATIONIMAGES_${i}_IMAGE"
         destination_repository_url_envvar="BUILDKITE_PLUGIN_K8S_DEPLOY_DESTINATIONIMAGES_${i}_REPOSITORYURL"
 
@@ -434,13 +414,11 @@ function promoteImage () {
     done
 
     # Clean up the source image if it didn't exist when we started
-
     if [ "$should_cleanup_source_image" -eq "1" ]; then
         docker image rm $BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_REPOSITORYURL/$BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_IMAGE
     fi
 
     # Fail this build step if there was any failures pushing an image
-
     if [ "$failure_count" -eq "0" ]; then
         exit 0
     else

--- a/hooks/command
+++ b/hooks/command
@@ -357,14 +357,14 @@ function promoteImage () {
     # Test if the image already exists on the kubernetes host
     local should_cleanup_source_image=1
 
-    if docker inspect --type=image $BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_REPOSITORYURL/$BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_IMAGE ; then
+    if docker inspect --type=image "$BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_REPOSITORYURL/$BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_IMAGE" ; then
         echo "Image tag already exists on host"
         should_cleanup_source_image=0
     fi
 
     # Pull the source image
-    docker pull $BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_REPOSITORYURL/$BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_IMAGE
-    if [ $? -ne 0 ]; then
+    if ! docker pull "$BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_REPOSITORYURL/$BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_IMAGE"
+    then
         echo "--- :bk-status-failed: Promotion failed. Failed to pull source image"
         exit 1
     fi
@@ -373,13 +373,11 @@ function promoteImage () {
     local i=0
     local destination_image_envvar="BUILDKITE_PLUGIN_K8S_DEPLOY_DESTINATIONIMAGES_${i}_IMAGE"
     local destination_repository_url_envvar="BUILDKITE_PLUGIN_K8S_DEPLOY_DESTINATIONIMAGES_${i}_REPOSITORYURL"
-    local destination_region_envvar="BUILDKITE_PLUGIN_K8S_DEPLOY_DESTINATIONIMAGES_${i}_REGION"
-
     local push_pids=()
 
     while [[ -n "${!destination_image_envvar:-}" ]] ; do
         # Tag and push the image
-        docker tag $BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_REPOSITORYURL/$BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_IMAGE ${!destination_repository_url_envvar}/${!destination_image_envvar}
+        docker tag "$BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_REPOSITORYURL/$BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_IMAGE" "${!destination_repository_url_envvar}/${!destination_image_envvar}"
 
         # Start push in parallel
         docker push ${!destination_repository_url_envvar}/${!destination_image_envvar} &
@@ -388,14 +386,13 @@ function promoteImage () {
         i=$((i+1))
         destination_image_envvar="BUILDKITE_PLUGIN_K8S_DEPLOY_DESTINATIONIMAGES_${i}_IMAGE"
         destination_repository_url_envvar="BUILDKITE_PLUGIN_K8S_DEPLOY_DESTINATIONIMAGES_${i}_REPOSITORYURL"
-        destination_region_envvar="BUILDKITE_PLUGIN_K8S_DEPLOY_DESTINATIONIMAGES_${i}_REGION"
     done
 
     # Wait for each image push to complete
     local failure_count=0
 
-    for i in ${!push_pids[@]}; do
-        wait ${push_pids[$i]}
+    for i in "${!push_pids[@]}"; do
+        wait "${push_pids[$i]}"
 
         local push_exit_code=$?
 
@@ -403,7 +400,7 @@ function promoteImage () {
         destination_image_envvar="BUILDKITE_PLUGIN_K8S_DEPLOY_DESTINATIONIMAGES_${i}_IMAGE"
         destination_repository_url_envvar="BUILDKITE_PLUGIN_K8S_DEPLOY_DESTINATIONIMAGES_${i}_REPOSITORYURL"
 
-        docker rmi ${!destination_repository_url_envvar}/${!destination_image_envvar}
+        docker rmi "${!destination_repository_url_envvar}/${!destination_image_envvar}"
 
         if [ "$push_exit_code" -ne "0" ]; then
             echo "--- :bk-status-failed: Promotion failed. Push failed to destination repository ${!destination_repository_url_envvar}"
@@ -415,7 +412,7 @@ function promoteImage () {
 
     # Clean up the source image if it didn't exist when we started
     if [ "$should_cleanup_source_image" -eq "1" ]; then
-        docker image rm $BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_REPOSITORYURL/$BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_IMAGE
+        docker image rm "$BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_REPOSITORYURL/$BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_IMAGE"
     fi
 
     # Fail this build step if there was any failures pushing an image

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,9 +1,29 @@
 ## Testing this plugin
 
-Follow the guidelines in the [Buildkite plugins documentation](https://buildkite.com/docs/plugins/writing#step-5-add-a-test). The easist way to run these tests is with Docker using this command:
+Follow the guidelines in the [Buildkite plugins documentation](https://buildkite.com/docs/plugins/writing#step-5-add-a-test).
+
+The easist way to run these tests is with Docker using this command in the top
+level directory, where the docker-compose.yml file is.
 
 ```sh
-docker run -it --rm -v "$PWD:/plugin:ro" buildkite/plugin-tester
+docker compose run --rm tests
 ```
 
 Take a look at the [plugin test documentation](https://github.com/buildkite-plugins/buildkite-plugin-tester) to find out how to use assertions, mocks etc.
+
+### Debugging Stubs
+
+This is explained in the docs as well but is very useful. If you are stubbing an
+executable like docker, then you can debug it by adding a matching ENV variable
+like this:
+
+```
+@test "cleans up image if it did not exist on host" {
+    stub docker \
+         "inspect \* \* : exit 1"
+
+    export DOCKER_STUB_DEBUG=3
+
+```
+
+When you run the tests you will see in the output exactly what is happening in the stub.

--- a/tests/helmDeploy.bats
+++ b/tests/helmDeploy.bats
@@ -2,9 +2,6 @@
 
 load "$BATS_PLUGIN_PATH/load.bash"
 
-# Uncomment the following line to debug stub failures
-# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
-
 setup() {
     export BUILDKITE_PLUGIN_K8S_DEPLOY_CHART="test-chart"
     export BUILDKITE_PLUGIN_K8S_DEPLOY_CHART_VERSION="0.1.14"

--- a/tests/promoteImage.bats
+++ b/tests/promoteImage.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+
+load "$BATS_PLUGIN_PATH/load.bash"
+
+setup() {
+    export BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_REPOSITORYURL="552375026182.dkr.ecr.ap-southeast-2.amazonaws.com"
+    export BUILDKITE_PLUGIN_K8S_DEPLOY_SOURCEIMAGE_IMAGE="website:test_tag"
+    export BUILDKITE_PLUGIN_K8S_DEPLOY_DESTINATIONIMAGES_0_REPOSITORYURL="587935219773.dkr.ecr.ap-southeast-2.amazonaws.com"
+    export BUILDKITE_PLUGIN_K8S_DEPLOY_DESTINATIONIMAGES_0_IMAGE="website:test_tag"
+    export BUILDKITE_PLUGIN_K8S_DEPLOY_DESTINATIONIMAGES_0_REGION="ap-southeast-2"
+    export BUILDKITE_PLUGIN_K8S_DEPLOY_ACTION="promoteImage"
+}
+
+teardown() {
+  unstub docker
+}
+
+@test "calls docker pull with the source image" {
+    stub docker \
+         "inspect \* \* : exit 0" \
+         "pull \* : echo \$2 > /tmp/docker-pull-image" \
+         "tag \* \* : exit 0" \
+         "push \* : exit 0" \
+         "rmi \* : exit 0" \
+
+    run "$PWD/hooks/command"
+
+    assert_success
+    pull_image="$(cat /tmp/docker-pull-image)"
+    assert_equal "${pull_image}" "552375026182.dkr.ecr.ap-southeast-2.amazonaws.com/website:test_tag"
+}
+
+@test "calls docker tag, push, rmi with correct destination" {
+    stub docker \
+         "inspect \* \* : exit 0" \
+         "pull \* : exit 0" \
+         "tag \* \* : echo \$2 > /tmp/docker_tag" \
+         "push \* : echo \$2 > /tmp/docker_push" \
+         "rmi \* : echo \$2 > /tmp/docker_rmi" \
+
+         run "$PWD/hooks/command"
+
+    assert_success
+    docker_tag="$(cat /tmp/docker_tag)"
+    docker_push="$(cat /tmp/docker_push)"
+    docker_rmi="$(cat /tmp/docker_rmi)"
+    assert_equal "${docker_tag}" "552375026182.dkr.ecr.ap-southeast-2.amazonaws.com/website:test_tag"
+    assert_equal "${docker_push}" "587935219773.dkr.ecr.ap-southeast-2.amazonaws.com/website:test_tag"
+    assert_equal "${docker_rmi}" "587935219773.dkr.ecr.ap-southeast-2.amazonaws.com/website:test_tag"
+    assert_output --partial "Image promotion success"
+}
+
+@test "promoteImage fails if image cannot be pulled" {
+    stub docker \
+         "inspect \* \* : exit 0" \
+         "pull \* : exit 1" \
+
+         run "$PWD/hooks/command"
+
+    assert_failure
+    assert_output --partial "Failed to pull source image"
+}
+
+@test "promoteImage fails if image cannot be pushed" {
+    stub docker \
+         "inspect \* \* : exit 0" \
+         "pull \* : exit 0" \
+         "tag \* \* : exit 0" \
+         "push \* : exit 1" \
+         "rmi \* : exit 0" \
+
+         run "$PWD/hooks/command"
+
+    assert_failure
+    assert_output --partial "Promotion failed"
+}
+
+@test "cleans up image if it did not exist on host" {
+    stub docker \
+         "inspect \* \* : exit 1" \
+         "pull \* : exit 0" \
+         "tag \* \* : exit 0" \
+         "push \* : exit 0" \
+         "rmi \* : exit 0" \
+         "image rm \* : echo 'image rm called'"
+
+    run "$PWD/hooks/command"
+
+    assert_success
+    assert_output --partial "image rm called"
+}
+
+@test "does not clean up image if it did exist on host" {
+    stub docker \
+         "inspect \* \* : exit 0" \
+         "pull \* : exit 0" \
+         "tag \* \* : exit 0" \
+         "push \* : exit 0" \
+         "rmi \* : exit 0"
+
+    run "$PWD/hooks/command"
+
+    assert_success
+    refute_output --partial "image rm called"
+}


### PR DESCRIPTION
This change removes calls to docker login. Authenticating with ECRs should be done with the the ecr-buildkite-plugin.
See: https://github.com/buildkite-plugins/ecr-buildkite-plugin

- also adds tests for `promoteImage`
- linting on `promoteImage`